### PR TITLE
Fix: Can't find 'Pokemon Explorer v3'. Cant find gengar

### DIFF
--- a/server.js
+++ b/server.js
@@ -93,6 +93,13 @@ const mockPokemons = [
     type: ['Psychic'],
     legendary: false,
     image: 'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/65.png'
+  },
+  {
+    id: 13,
+    name: 'Gengar',
+    type: ['Ghost', 'Poison'],
+    legendary: false,
+    image: 'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/94.png'
   }
 ];
 


### PR DESCRIPTION
 **PR Generated by testRigor CodeGen AI Agent**
Fix issue: "Can't find 'Pokemon Explorer v3'. Cant find gengar"

The description that explains the issue is: ""

Test case run: 